### PR TITLE
Fix weekly MVP calculation

### DIFF
--- a/mvp_semanal_stats.py
+++ b/mvp_semanal_stats.py
@@ -76,7 +76,7 @@ def calcular_mvp_semanal(antes, despues):
 
 if __name__ == "__main__":
     hoy = datetime.today().date()
-    hace_una_semana = hoy - timedelta(days=1)
+    hace_una_semana = hoy - timedelta(days=7)
 
     fecha_actual = hoy.strftime("%Y-%m-%d")
     fecha_pasada = hace_una_semana.strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary
- update weekly MVP script so it looks back seven days instead of one

## Testing
- `python - <<'PY'
import mvp_semanal_stats
from datetime import datetime, timedelta

hoy = datetime(2025,7,3).date()
hace_una_semana = hoy - timedelta(days=7)
fecha_actual = hoy.strftime('%Y-%m-%d')
fecha_pasada = hace_una_semana.strftime('%Y-%m-%d')
snapshot_actual = mvp_semanal_stats.cargar_stats(fecha_actual)
snapshot_anterior = mvp_semanal_stats.cargar_stats(fecha_pasada)
if snapshot_actual and snapshot_anterior:
    ranking = mvp_semanal_stats.calcular_mvp_semanal(snapshot_anterior, snapshot_actual)
    print(f"\n🏆 MVP Semanal ({fecha_pasada} → {fecha_actual}):\n")
    for i, r in enumerate(ranking, 1):
        print(f"{i}. {r['jugador']} → {r['puntos']} pts")
        print(f"   🎯 {r['goles']} goles | 🎁 {r['asistencias']} asist. | 🧮 {r['partidos']} partidos")
        print(f"   ✅ {r['pases']} pases | 🛡️ {r['entradas']} entradas | 🥇 {r['mvps']} MVPs | ⭐ {r['valoracion']} val. media | 🟥 {r['rojas']} rojas\n")
PY

------
https://chatgpt.com/codex/tasks/task_e_6867d2590df0832c8bc636efcc031755